### PR TITLE
Fix quiz label

### DIFF
--- a/src/js/quiz-component.js
+++ b/src/js/quiz-component.js
@@ -56,7 +56,7 @@ const quizComponent = (quizInfo, callback) => {
     answer.dataset.answer = choice;
 
     const label = document.createElement("label");
-    label.setAttribute("for", `${choice}`);
+    label.setAttribute("for", `choice-${i}`);
     label.textContent = choice;
 
     form.appendChild(answer);


### PR DESCRIPTION
A quick fix to correctly link the quiz answers' labels to their respective radio buttons.
Should close #72 