### PR TITLE
fix storyEnd home button

### DIFF
--- a/src/js/storyEnd.js
+++ b/src/js/storyEnd.js
@@ -2,7 +2,7 @@
 
 //should implement a quiz in the future.
 
-function createStoryEnd(storyTitle, quiz, displayHome) {
+function createStoryEnd(storyTitle, displayHome) {
   const base = document.createElement("div");
   base.id = "story-end";
 


### PR DESCRIPTION
In the end it was a pretty quick fix, I just had to remove the unused `quiz` argument in createStoryEnd.
But fixing this created another issue, if the player plays through the game, clicks the home button on the end screen then plays again, they'll get stuck on the page right before the quiz ("Dear, that is all etc...), the next button doesn't work here, but only on the second playthrough in a row.