### PR TITLE
Added user-drag: none to drop container img

### DIFF
--- a/src/js/chapterDOM.js
+++ b/src/js/chapterDOM.js
@@ -60,6 +60,7 @@ const createChapterStructure = (chapterObj, displayHome, callback) => {
 
       const picture = document.createElement("img");
       picture.src = image.url;
+      picture.draggable = false;
 
       const pictureContainer = document.createElement("div");
       pictureContainer.classList.add("picture")

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -169,6 +169,7 @@ img {
 }
 
 .drop-container img {
+  -webkit-user-drag: none;
   opacity: 0;
 }
 


### PR DESCRIPTION
Very small CSS addition, but previously players could drag the drop container image to see the answer. User-drag: none prevents this. 